### PR TITLE
Cleanly do a compose down

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -114,6 +114,7 @@ function dockerComposeUp() {
 function dockerComposeDown() {
     dockerComposeFiles
     if [ $($dccmd ps | wc -l) -gt 2 ]; then
+        $dccmd rm --stop --force
         $dccmd down
     fi
 }


### PR DESCRIPTION
Without this change, we will regularly get error like this:

```
 Removing network docker_public

error while removing network: network docker_public id 123ABC has active endpoints
```